### PR TITLE
tp30307 feat: Set row-cell max-width

### DIFF
--- a/src/section-row-cell/style.scss
+++ b/src/section-row-cell/style.scss
@@ -3,4 +3,5 @@
   display: flex;
   flex-direction: column;
   flex-basis: 100%; // IE11
+  max-width: inherit; // IE11
 }


### PR DESCRIPTION
In order to fix the [Oversized image in cell](https://front.tpondemand.com/entity/30307-oversized-image-in-cell) in IE, `max-width: inherit` was added to Section Row Cell style. 

I think it won't affect anything else in the block but I'm not familiar with the block, so I'm asking for your opinion @ajotka and @fragje.