### PR TITLE
Set gallery and image height inside section-row-cell 

### DIFF
--- a/src/section-row-cell/style.scss
+++ b/src/section-row-cell/style.scss
@@ -4,4 +4,16 @@
   flex-direction: column;
   flex-basis: 100%; // IE11
   max-width: inherit; // IE11
+
+  > * {
+    height: 100%,
+  }
+
+  > .wp-block-gallery.is-cropped {
+    .blocks-gallery-item {
+      img {
+        height: 100%;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Again, to fix IE issues I've set the gallery and gallery images `height` to 100% (inside the **section-row-cell**).